### PR TITLE
Disable nodeIntegration for YouTube renderer

### DIFF
--- a/renderers/main/injection.js
+++ b/renderers/main/injection.js
@@ -115,9 +115,6 @@ const loadConnectionWarnings = () => {
  */
 const loadConnectionEvents = () => {
 
-    // Carga el IPC de electron.
-    window.ipc = window.require('electron').ipcRenderer;
-
     // Declara el aviso de restauración de conexión.
     const rest = document.getElementById('rest');
 

--- a/renderers/main/main.renderer.ts
+++ b/renderers/main/main.renderer.ts
@@ -101,10 +101,11 @@ export class Renderer {
       backgroundColor: "#282828",
       icon: nativeImage.createFromPath(join(cwd(), "build", "icon.png")),
       webPreferences: {
-        nodeIntegration: true,
+        nodeIntegration: false,
         webSecurity: true,
         contextIsolation: false,
         backgroundThrottling: false,
+        preload: join(__dirname, "preload.js"),
       },
     });
 

--- a/renderers/main/offline_banner.js
+++ b/renderers/main/offline_banner.js
@@ -5,7 +5,7 @@
  * no está disponible, este script mostrará un mensaje de estado.
  */
 
-const ipc = window.require('electron').ipcRenderer;
+const ipc = window.ipc;
 const styles = document.createElement('style');
 const banner_cont = document.createElement('div');
 const offline_picture = document.createElement('div');


### PR DESCRIPTION
YouTube's website does not need access to `require()`, and it's good security to drop unnecessary capabilities.

With `nodeIntegration` left enabled, it opens up the possibility for the YouTube website to read or write files on the local filesystem or do anything else NodeJS can do. While it's extremely unlikely that would ever happen, it's still a good idea to keep a remotely-loaded website properly sandboxed.

Access to the Electron `ipcRenderer` is still provided via `window.ipc`.
