### PR TITLE
Fix `visibilitychange` event overriding

### DIFF
--- a/renderers/main/injection.js
+++ b/renderers/main/injection.js
@@ -22,11 +22,11 @@ Object.keys(msgDB).forEach(lang => {
  */
 const visibilityChangeOverriding = () => {
 
-    document.addEventListener('webkitvisibilitychange', event => {
+    window.addEventListener('webkitvisibilitychange', event => {
         event.stopImmediatePropagation();
     }, true);
 
-    document.addEventListener('visibilitychange', event => {
+    window.addEventListener('visibilitychange', event => {
         event.stopImmediatePropagation();
     }, true);
 


### PR DESCRIPTION
This prevents YoutubeTV from automatically pausing when minimized to the task bar in Windows.
